### PR TITLE
Test on django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ env:
         
   - DJANGO=1.7
     PSQL=1
+
+  - DJANGO=1.8
+    PSQL=0
+
+  - DJANGO=1.8
+    PSQL=1
     
 before_script:
   - psql -c 'create database travisci;' -U postgres


### PR DESCRIPTION
Even though Django 1.8 now has [DurationField](https://docs.djangoproject.com/en/1.8/ref/models/fields/#django.db.models.DurationField),
I'm not clear on the migration path for those of us using
django-interval-field, and we might as well test on django 1.8.